### PR TITLE
Recurse new node's children when a node is replaced in LuceneTreeTransformer

### DIFF
--- a/luqum/utils.py
+++ b/luqum/utils.py
@@ -114,8 +114,7 @@ class LuceneTreeTransformer(LuceneTreeVisitor):
         new_node = method(node, parents)
         if parents:
             self.replace_node(node, new_node, parents[-1])
-        else:
-            node = new_node
+        node = new_node
         for child in node.children:
             self.visit(child, parents + [node])
         return node


### PR DESCRIPTION
This changes the behaviour of `LuceneTreeTransformer.visit` when a node is replaced. Rather than recursing through the children of the node that was replaced, we instead recurse through the children of the new node.