### PR TITLE
Fix ES query builder handling of empty phrases

### DIFF
--- a/luqum/elasticsearch/tests/tests.py
+++ b/luqum/elasticsearch/tests/tests.py
@@ -151,6 +151,12 @@ class ElasticsearchTreeTransformerTestCase(TestCase):
         expected = {"match_phrase": {"text": {"query": 'spam eggs'}}}
         self.assertDictEqual(result, expected)
 
+    def test_should_transform_empty_phrase(self):
+        tree = Phrase('""')
+        result = self.transformer(tree)
+        expected = {"match_phrase": {"text": {"query": ''}}}
+        self.assertDictEqual(result, expected)
+
     def test_should_transform_phrase_with_custom_search_field(self):
         transformer = ElasticsearchQueryBuilder(default_field="custom")
         tree = Phrase('"spam eggs"')

--- a/luqum/elasticsearch/tree.py
+++ b/luqum/elasticsearch/tree.py
@@ -149,7 +149,7 @@ class EPhrase(AbstractEItem):
         return re.sub(r'\s+', ' ', phrase)
 
     def _remove_double_quotes(self, phrase):
-        return re.search(r'"(?P<value>.+)"', phrase).group("value")
+        return phrase[1:-1]
 
     @property
     def slop(self):


### PR DESCRIPTION
When removing quotes from a phrase, the ES query builder required a non-empty quoted string, and would raise a TypeError when presented with an empty one. Switching from a regex to a simple slice removing the first and last character from the phrase solves the problem.

Fixes #4.

Mayhaps this and #7 would merit a release :smile: 