### PR TITLE
Remove "type": "phrase" from `match` queries

### DIFF
--- a/luqum/elasticsearch/tree.py
+++ b/luqum/elasticsearch/tree.py
@@ -48,7 +48,6 @@ class AbstractEItem(JsonSerializableMixin):
             if value is not None:
                 if key == 'q' and self.method == 'match':
                     inner_json['query'] = value
-                    inner_json['type'] = 'phrase'
                     inner_json['zero_terms_query'] = self.zero_terms_query
                 elif key == 'q' and self.method == 'query_string':
                     inner_json['query'] = value


### PR DESCRIPTION
I don't expect you'd like to take this PR as-is.  I would like you to consider making the choice between `match` and `match_phrase` queries configurable somehow.  For my use-cases the `match_phrase` query isn't appropriate, so I just removed it.  I think `match_phrase` should be the default (as it is the only choice now), with the ability to configure behavior (ideally per field/subfield).

Also, "type": "phrase" is deprecated by newer versions of ES.  I get a warning like this when I try to execute a query built with "type": "phrase" in it:

```
#! Deprecation: Deprecated field [type] used, replaced by [match_phrase and match_phrase_prefix query]
```