### PR TITLE
Support multi_match query type

### DIFF
--- a/luqum/__init__.py
+++ b/luqum/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.7.5'
+__version__ = '0.8.0'
 __version_info__ = tuple(__version__.split('.'))

--- a/luqum/elasticsearch/tree.py
+++ b/luqum/elasticsearch/tree.py
@@ -38,8 +38,10 @@ class AbstractEItem(JsonSerializableMixin):
     def json(self):
         field = self.field
         inner_json = dict(self.field_options.get(field, {}))
-        inner_json.pop('type', None)  # remove "type" key
-        if self.method == 'query_string':
+        result = inner_json.pop('match_type', None)  # remove "match_type" key
+        if not result: # only pop the type key if match_type wasn't used (for backward compatibility)
+            inner_json.pop('type', None)
+        if self.method in ['query_string', 'multi_match']:
             json = {self.method: inner_json}
         else:
             json = {self.method: {field: inner_json}}
@@ -50,7 +52,7 @@ class AbstractEItem(JsonSerializableMixin):
             value = getattr(self, key, None)
             if value is not None:
                 if key == 'q':
-                    if self.method.startswith('match'):
+                    if 'match' in self.method:
                         inner_json['query'] = value
                         if self.method == 'match':
                             inner_json['zero_terms_query'] = self.zero_terms_query
@@ -94,7 +96,9 @@ class AbstractEItem(JsonSerializableMixin):
             if self._value_has_wildcard_char():
                 return 'query_string'
             elif self._method.startswith("match"):
-                return self.field_options.get(self.field, {}).get("type", self._method)
+             options = self.field_options.get(self.field, {})
+             # Support the type opiton for backward compatibility
+             return options.get("match_type", options.get("type", self._method))
         return self._method
 
 

--- a/luqum/elasticsearch/tree.py
+++ b/luqum/elasticsearch/tree.py
@@ -39,7 +39,7 @@ class AbstractEItem(JsonSerializableMixin):
         field = self.field
         inner_json = dict(self.field_options.get(field, {}))
         result = inner_json.pop('match_type', None)  # remove "match_type" key
-        if not result: # only pop the type key if match_type wasn't used (for backward compatibility)
+        if not result:  # conditionally remove "type" (for backward compatibility)
             inner_json.pop('type', None)
         if self.method in ['query_string', 'multi_match']:
             json = {self.method: inner_json}
@@ -96,9 +96,9 @@ class AbstractEItem(JsonSerializableMixin):
             if self._value_has_wildcard_char():
                 return 'query_string'
             elif self._method.startswith("match"):
-             options = self.field_options.get(self.field, {})
-             # Support the type opiton for backward compatibility
-             return options.get("match_type", options.get("type", self._method))
+                options = self.field_options.get(self.field, {})
+                # Support the type opiton for backward compatibility
+                return options.get("match_type", options.get("type", self._method))
         return self._method
 
 

--- a/luqum/elasticsearch/visitor.py
+++ b/luqum/elasticsearch/visitor.py
@@ -79,7 +79,7 @@ class ElasticsearchQueryBuilder(LuceneTreeVisitorV2):
           None, will accept all non nested fields or object fields as sub fields.
         :param dict field_options: allows you to give defaults options for each fields.
           They will be applied unless, overwritten by generated parameters.
-          For match query, the `type` parameter modifies the query type.
+          For match query, the `match_type` parameter modifies the type of match query.
         :param bool match_word_as_phrase: if True,
           word expressions are matched using `match_phrase` instead of `match`.
           This options mainly keeps stability with 0.6 version.


### PR DESCRIPTION
This solves a problem I had trying to use `multi_match` queries, figured I'd see if it made sense to merge it up stream.

It enables setting up a field to be converted to a [multi_match](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html) query in order to automatically query its subfields as well. E.g.:
``` python
es_query_builder = ElasticsearchQueryBuilder(
    field_options={
        'title': {
            'match_type': 'multi_match',
            'type': 'bool_prefix',
            'fields': ['title', 'title.ngram', 'title.raw']
        }
    }
)
```

`muli_match` has a property called `type` so I needed to rename the special `field_option` `type` case to `match_type`. If `match_type` isn't used it falls back to `type` for backward compatibility.