### PR TITLE
Add basic support for regex type in parser

### DIFF
--- a/luqum/parsetab.py
+++ b/luqum/parsetab.py
@@ -6,9 +6,9 @@ _tabversion = '3.10'
 
 _lr_method = 'LALR'
 
-_lr_signature = 'leftOR_OPleftAND_OPnonassocMINUSnonassocPLUSnonassocAPPROXnonassocBOOSTnonassocLPARENRPARENnonassocLBRACKETTORBRACKETnonassocPHRASEnonassocTERMAND_OP APPROX BOOST COLUMN LBRACKET LPAREN MINUS NOT OR_OP PHRASE PLUS RBRACKET RPAREN TERM TOexpression : expression OR_OP expressionexpression : expression AND_OP expressionexpression : expression expressionunary_expression : PLUS unary_expressionunary_expression : MINUS unary_expressionunary_expression : NOT unary_expressionexpression : unary_expressionunary_expression : LPAREN expression RPARENunary_expression : LBRACKET phrase_or_term TO phrase_or_term RBRACKETunary_expression : TERM COLUMN unary_expressionunary_expression : PHRASEunary_expression : PHRASE APPROXexpression : expression BOOSTunary_expression : TERMunary_expression : TERM APPROXunary_expression : TOphrase_or_term : TERM\n                      | PHRASE'
+_lr_signature = 'leftOR_OPleftAND_OPnonassocMINUSnonassocPLUSnonassocAPPROXnonassocBOOSTnonassocLPARENRPARENnonassocLBRACKETTORBRACKETnonassocREGEXnonassocPHRASEnonassocTERMAND_OP APPROX BOOST COLUMN LBRACKET LPAREN MINUS NOT OR_OP PHRASE PLUS RBRACKET REGEX RPAREN TERM TOexpression : expression OR_OP expressionexpression : expression AND_OP expressionexpression : expression expressionunary_expression : PLUS unary_expressionunary_expression : MINUS unary_expressionunary_expression : NOT unary_expressionexpression : unary_expressionunary_expression : LPAREN expression RPARENunary_expression : LBRACKET phrase_or_term TO phrase_or_term RBRACKETunary_expression : TERM COLUMN unary_expressionunary_expression : PHRASEunary_expression : PHRASE APPROXexpression : expression BOOSTunary_expression : TERMunary_expression : TERM APPROXunary_expression : REGEXunary_expression : TOphrase_or_term : TERM\n                      | PHRASE'
     
-_lr_action_items = {'PLUS':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,22,23,24,25,26,27,29,31,],[3,3,-7,3,3,3,3,-16,-14,-11,3,3,3,-13,-4,-5,-6,3,3,-15,-12,3,3,-8,-10,-9,]),'MINUS':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,22,23,24,25,26,27,29,31,],[4,4,-7,4,4,4,4,-16,-14,-11,4,4,4,-13,-4,-5,-6,4,4,-15,-12,4,4,-8,-10,-9,]),'NOT':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,22,23,24,25,26,27,29,31,],[5,5,-7,5,5,5,5,-16,-14,-11,5,5,5,-13,-4,-5,-6,5,5,-15,-12,-1,-2,-8,-10,-9,]),'LPAREN':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,22,23,24,25,26,27,29,31,],[6,6,-7,6,6,6,6,-16,-14,-11,6,6,6,-13,-4,-5,-6,6,6,-15,-12,6,6,-8,-10,-9,]),'LBRACKET':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,22,23,24,25,26,27,29,31,],[7,7,-7,7,7,7,7,-16,-14,-11,7,7,7,-13,-4,-5,-6,7,7,-15,-12,7,7,-8,-10,-9,]),'TERM':([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,22,23,24,25,26,27,28,29,31,],[9,9,-7,9,9,9,9,20,-16,-14,-11,9,9,9,-13,-4,-5,-6,9,9,-15,-12,9,9,-8,20,-10,-9,]),'PHRASE':([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,22,23,24,25,26,27,28,29,31,],[10,10,-7,10,10,10,10,21,-16,-14,-11,10,10,10,-13,-4,-5,-6,10,10,-15,-12,10,10,-8,21,-10,-9,]),'TO':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,29,31,],[8,8,-7,8,8,8,8,-16,-14,-11,8,8,8,-13,-4,-5,-6,8,28,-17,-18,8,-15,-12,8,8,-8,-10,-9,]),'$end':([1,2,8,9,10,11,14,15,16,17,23,24,25,26,27,29,31,],[0,-7,-16,-14,-11,-3,-13,-4,-5,-6,-15,-12,-1,-2,-8,-10,-9,]),'OR_OP':([1,2,8,9,10,11,14,15,16,17,18,23,24,25,26,27,29,31,],[12,-7,-16,-14,-11,12,-13,-4,-5,-6,12,-15,-12,-1,-2,-8,-10,-9,]),'AND_OP':([1,2,8,9,10,11,14,15,16,17,18,23,24,25,26,27,29,31,],[13,-7,-16,-14,-11,13,-13,-4,-5,-6,13,-15,-12,13,-2,-8,-10,-9,]),'BOOST':([1,2,8,9,10,11,14,15,16,17,18,23,24,25,26,27,29,31,],[14,-7,-16,-14,-11,14,-13,-4,-5,-6,14,-15,-12,14,14,-8,-10,-9,]),'RPAREN':([2,8,9,10,11,14,15,16,17,18,23,24,25,26,27,29,31,],[-7,-16,-14,-11,-3,-13,-4,-5,-6,27,-15,-12,-1,-2,-8,-10,-9,]),'COLUMN':([9,],[22,]),'APPROX':([9,10,],[23,24,]),'RBRACKET':([20,21,30,],[-17,-18,31,]),}
+_lr_action_items = {'PLUS':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[3,3,-7,3,3,3,3,-17,-14,-11,-16,3,3,3,-13,-4,-5,-6,3,3,-15,-12,3,3,-8,-10,-9,]),'MINUS':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[4,4,-7,4,4,4,4,-17,-14,-11,-16,4,4,4,-13,-4,-5,-6,4,4,-15,-12,4,4,-8,-10,-9,]),'NOT':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[5,5,-7,5,5,5,5,-17,-14,-11,-16,5,5,5,-13,-4,-5,-6,5,5,-15,-12,-1,-2,-8,-10,-9,]),'LPAREN':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[6,6,-7,6,6,6,6,-17,-14,-11,-16,6,6,6,-13,-4,-5,-6,6,6,-15,-12,6,6,-8,-10,-9,]),'LBRACKET':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[7,7,-7,7,7,7,7,-17,-14,-11,-16,7,7,7,-13,-4,-5,-6,7,7,-15,-12,7,7,-8,-10,-9,]),'TERM':([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,29,30,32,],[9,9,-7,9,9,9,9,21,-17,-14,-11,-16,9,9,9,-13,-4,-5,-6,9,9,-15,-12,9,9,-8,21,-10,-9,]),'PHRASE':([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,29,30,32,],[10,10,-7,10,10,10,10,22,-17,-14,-11,-16,10,10,10,-13,-4,-5,-6,10,10,-15,-12,10,10,-8,22,-10,-9,]),'REGEX':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[11,11,-7,11,11,11,11,-17,-14,-11,-16,11,11,11,-13,-4,-5,-6,11,11,-15,-12,11,11,-8,-10,-9,]),'TO':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,30,32,],[8,8,-7,8,8,8,8,-17,-14,-11,-16,8,8,8,-13,-4,-5,-6,8,29,-18,-19,8,-15,-12,8,8,-8,-10,-9,]),'$end':([1,2,8,9,10,11,12,15,16,17,18,24,25,26,27,28,30,32,],[0,-7,-17,-14,-11,-16,-3,-13,-4,-5,-6,-15,-12,-1,-2,-8,-10,-9,]),'OR_OP':([1,2,8,9,10,11,12,15,16,17,18,19,24,25,26,27,28,30,32,],[13,-7,-17,-14,-11,-16,13,-13,-4,-5,-6,13,-15,-12,-1,-2,-8,-10,-9,]),'AND_OP':([1,2,8,9,10,11,12,15,16,17,18,19,24,25,26,27,28,30,32,],[14,-7,-17,-14,-11,-16,14,-13,-4,-5,-6,14,-15,-12,14,-2,-8,-10,-9,]),'BOOST':([1,2,8,9,10,11,12,15,16,17,18,19,24,25,26,27,28,30,32,],[15,-7,-17,-14,-11,-16,15,-13,-4,-5,-6,15,-15,-12,15,15,-8,-10,-9,]),'RPAREN':([2,8,9,10,11,12,15,16,17,18,19,24,25,26,27,28,30,32,],[-7,-17,-14,-11,-16,-3,-13,-4,-5,-6,28,-15,-12,-1,-2,-8,-10,-9,]),'COLUMN':([9,],[23,]),'APPROX':([9,10,],[24,25,]),'RBRACKET':([21,22,31,],[-18,-19,32,]),}
 
 _lr_action = {}
 for _k, _v in _lr_action_items.items():
@@ -17,7 +17,7 @@ for _k, _v in _lr_action_items.items():
       _lr_action[_x][_k] = _y
 del _lr_action_items
 
-_lr_goto_items = {'expression':([0,1,6,11,12,13,18,25,26,],[1,11,18,11,25,26,11,11,11,]),'unary_expression':([0,1,3,4,5,6,11,12,13,18,22,25,26,],[2,2,15,16,17,2,2,2,2,2,29,2,2,]),'phrase_or_term':([7,28,],[19,30,]),}
+_lr_goto_items = {'expression':([0,1,6,12,13,14,19,26,27,],[1,12,19,12,26,27,12,12,12,]),'unary_expression':([0,1,3,4,5,6,12,13,14,19,23,26,27,],[2,2,16,17,18,2,2,2,2,2,30,2,2,]),'phrase_or_term':([7,29,],[20,31,]),}
 
 _lr_goto = {}
 for _k, _v in _lr_goto_items.items():
@@ -27,22 +27,23 @@ for _k, _v in _lr_goto_items.items():
 del _lr_goto_items
 _lr_productions = [
   ("S' -> expression","S'",1,None,None,None),
-  ('expression -> expression OR_OP expression','expression',3,'p_expression_or','parser.py',170),
-  ('expression -> expression AND_OP expression','expression',3,'p_expression_and','parser.py',175),
-  ('expression -> expression expression','expression',2,'p_expression_implicit','parser.py',180),
-  ('unary_expression -> PLUS unary_expression','unary_expression',2,'p_expression_plus','parser.py',185),
-  ('unary_expression -> MINUS unary_expression','unary_expression',2,'p_expression_minus','parser.py',190),
-  ('unary_expression -> NOT unary_expression','unary_expression',2,'p_expression_not','parser.py',195),
-  ('expression -> unary_expression','expression',1,'p_expression_unary','parser.py',200),
-  ('unary_expression -> LPAREN expression RPAREN','unary_expression',3,'p_grouping','parser.py',205),
-  ('unary_expression -> LBRACKET phrase_or_term TO phrase_or_term RBRACKET','unary_expression',5,'p_range','parser.py',210),
-  ('unary_expression -> TERM COLUMN unary_expression','unary_expression',3,'p_field_search','parser.py',217),
-  ('unary_expression -> PHRASE','unary_expression',1,'p_quoting','parser.py',225),
-  ('unary_expression -> PHRASE APPROX','unary_expression',2,'p_proximity','parser.py',230),
-  ('expression -> expression BOOST','expression',2,'p_boosting','parser.py',235),
-  ('unary_expression -> TERM','unary_expression',1,'p_terms','parser.py',240),
-  ('unary_expression -> TERM APPROX','unary_expression',2,'p_fuzzy','parser.py',245),
-  ('unary_expression -> TO','unary_expression',1,'p_to_as_term','parser.py',251),
-  ('phrase_or_term -> TERM','phrase_or_term',1,'p_phrase_or_term','parser.py',256),
-  ('phrase_or_term -> PHRASE','phrase_or_term',1,'p_phrase_or_term','parser.py',257),
+  ('expression -> expression OR_OP expression','expression',3,'p_expression_or','parser.py',191),
+  ('expression -> expression AND_OP expression','expression',3,'p_expression_and','parser.py',196),
+  ('expression -> expression expression','expression',2,'p_expression_implicit','parser.py',201),
+  ('unary_expression -> PLUS unary_expression','unary_expression',2,'p_expression_plus','parser.py',206),
+  ('unary_expression -> MINUS unary_expression','unary_expression',2,'p_expression_minus','parser.py',211),
+  ('unary_expression -> NOT unary_expression','unary_expression',2,'p_expression_not','parser.py',216),
+  ('expression -> unary_expression','expression',1,'p_expression_unary','parser.py',221),
+  ('unary_expression -> LPAREN expression RPAREN','unary_expression',3,'p_grouping','parser.py',226),
+  ('unary_expression -> LBRACKET phrase_or_term TO phrase_or_term RBRACKET','unary_expression',5,'p_range','parser.py',231),
+  ('unary_expression -> TERM COLUMN unary_expression','unary_expression',3,'p_field_search','parser.py',238),
+  ('unary_expression -> PHRASE','unary_expression',1,'p_quoting','parser.py',246),
+  ('unary_expression -> PHRASE APPROX','unary_expression',2,'p_proximity','parser.py',251),
+  ('expression -> expression BOOST','expression',2,'p_boosting','parser.py',256),
+  ('unary_expression -> TERM','unary_expression',1,'p_terms','parser.py',261),
+  ('unary_expression -> TERM APPROX','unary_expression',2,'p_fuzzy','parser.py',266),
+  ('unary_expression -> REGEX','unary_expression',1,'p_regex','parser.py',270),
+  ('unary_expression -> TO','unary_expression',1,'p_to_as_term','parser.py',275),
+  ('phrase_or_term -> TERM','phrase_or_term',1,'p_phrase_or_term','parser.py',280),
+  ('phrase_or_term -> PHRASE','phrase_or_term',1,'p_phrase_or_term','parser.py',281),
 ]

--- a/luqum/tests/tests.py
+++ b/luqum/tests/tests.py
@@ -11,7 +11,7 @@ from ..parser import lexer, parser, ParseError
 from ..pretty import Prettifier, prettify
 from ..tree import (
     SearchField, FieldGroup, Group,
-    Term, Word, Phrase, Proximity, Fuzzy, Boost, Range,
+    Term, Word, Phrase, Regex, Proximity, Fuzzy, Boost, Range,
     Not, AndOperation, OrOperation, Plus, Prohibit, UnknownOperation)
 from ..utils import (
     LuceneTreeVisitor,
@@ -269,6 +269,15 @@ class TestParser(TestCase):
                 Phrase('"a phrase (AND a complicated~ one)"'),
                 Phrase('"Another one"')))
         parsed = parser.parse('"a phrase (AND a complicated~ one)" AND "Another one"')
+        self.assertEqual(str(parsed), str(tree))
+        self.assertEqual(parsed, tree)
+
+    def test_regex(self):
+        tree = (
+            AndOperation(
+                Regex('/a regex (with some.*match+ing)?/'),
+                Regex('/Another one/')))
+        parsed = parser.parse('/a regex (with some.*match+ing)?/ AND /Another one/')
         self.assertEqual(str(parsed), str(tree))
         self.assertEqual(parsed, tree)
 

--- a/luqum/tree.py
+++ b/luqum/tree.py
@@ -206,6 +206,17 @@ class Phrase(Term):
                "Phrase value must contain the quotes")
 
 
+class Regex(Term):
+    """A regex term, that is a sequence of words enclose in slashes
+
+    :param str value: the value, including the slashes. Eg. ``'/my regex/'``
+    """
+    def __init__(self, value):
+        super(Regex, self).__init__(value)
+        assert value.endswith('/') and value.startswith('/'), (
+               "Regex value must contain the slashes")
+
+
 class BaseApprox(Item):
     """Base for approximations, that is fuzziness and proximity
     """


### PR DESCRIPTION
This simply allows you to distinguish regex from
words. It does no internal parsing of the regex
text.

Before:

    >>> parser.parse('/foo bar/')
    UnknownOperation(Word('/foo'), Word('bar/'))

After:

    >>> parser.parse('/foo bar/')
    Regex('/foo bar/')