### PR TITLE
Add support for Lucene and Elasticsearch Boolean operations

### DIFF
--- a/luqum/elasticsearch/tree.py
+++ b/luqum/elasticsearch/tree.py
@@ -373,6 +373,32 @@ class EMustNot(AbstractEMustOperation):
     operation = 'must_not'
 
 
+class EBoolOperation(EOperation):
+
+    @property
+    def json(self):
+        must_items = []
+        should_items = []
+        must_not_items = []
+        for item in self.items:
+            if isinstance(item, EMust):
+                must_items.extend(item.items)
+            elif isinstance(item, EMustNot):
+                must_not_items.extend(item.items)
+            else:
+                should_items.append(item)
+        bool_query = {}
+        if must_items:
+            bool_query["must"] = [item.json for item in must_items]
+        if should_items:
+            bool_query["should"] = [item.json for item in should_items]
+        if must_not_items:
+            bool_query["must_not"] = [item.json for item in must_not_items]
+
+        query = dict(bool_query, **self.options)
+        return {'bool': query}
+
+
 class ElasticSearchItemFactory:
     """
     Factory to preconfigure EItems and EOperation

--- a/luqum/elasticsearch/visitor.py
+++ b/luqum/elasticsearch/visitor.py
@@ -6,7 +6,7 @@ from luqum.tree import OrOperation, AndOperation, UnknownOperation
 from luqum.tree import Word  # noqa: F401
 from .tree import (
     EMust, EMustNot, EShould, EWord, EPhrase, ERange,
-    ENested)
+    ENested, EBoolOperation)
 from ..check import CheckNestedFields
 from ..naming import get_name
 from ..utils import (
@@ -341,6 +341,9 @@ class ElasticsearchQueryBuilder(TreeVisitor):
 
     def visit_plus(self, *args, **kwargs):
         yield from self._must_operation(*args, **kwargs)
+
+    def visit_bool_operation(self, *args, **kwargs):
+        yield from self._binary_operation(EBoolOperation, *args, **kwargs)
 
     def visit_unknown_operation(self, *args, **kwargs):
         if self.default_operator == self.SHOULD:

--- a/luqum/tree.py
+++ b/luqum/tree.py
@@ -413,6 +413,21 @@ class BaseOperation(Item):
         self.operands = tuple(value)
 
 
+class BoolOperation(BaseOperation):
+    """Lucene Boolean Query.
+
+    This operation assumes that the query builder can utilize a boolean operator
+    with three possible sections, must, should and must_not. If the
+    UnknownOperationResolver is asked to resolve_to this operation, the query
+    builder can utilize this operator directly instead of nested AND/OR.
+    This also makes it possible to correctly support Lucene queries such as:
+    "apples +bananas -vegetables"
+    .. seealso::
+        the :py:class:`.utils.UnknownOperationResolver`
+    """
+    op = ""
+
+
 class UnknownOperation(BaseOperation):
     """Unknown Boolean operator.
 

--- a/luqum/utils.py
+++ b/luqum/utils.py
@@ -8,22 +8,22 @@ Include base classes to implement a visitor pattern.
 from . import visitor
 from .deprecated_utils import (  # noqa: F401
     LuceneTreeTransformer, LuceneTreeVisitor, LuceneTreeVisitorV2)
-from .tree import AndOperation, BaseOperation, OrOperation
+from .tree import AndOperation, BaseOperation, OrOperation, BoolOperation
 
 
 class UnknownOperationResolver(visitor.TreeTransformer):
     """Transform the UnknownOperation to OR or AND
     """
 
-    VALID_OPERATIONS = frozenset([None, AndOperation, OrOperation])
+    VALID_OPERATIONS = frozenset([None, AndOperation, OrOperation, BoolOperation])
     DEFAULT_OPERATION = AndOperation
 
     def __init__(self, resolve_to=None, add_head=" "):
         """Initialize a new resolver
 
-        :param resolve_to: must be either None, OrOperation or AndOperation.
+        :param resolve_to: must be either None, OrOperation, AndOperation, BoolOperation.
 
-          for the latter two the UnknownOperation is repalced by specified operation.
+          for the latter three the UnknownOperation is replaced by specified operation.
 
           if it is None, we use the last operation encountered, as would Lucene do
         """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 
 from luqum.parser import parser
-from luqum.tree import Group, Word, AndOperation, OrOperation, UnknownOperation
+from luqum.tree import (Group, Word, AndOperation, OrOperation, BoolOperation,
+                        UnknownOperation, Prohibit, Plus)
 from luqum.utils import UnknownOperationResolver
 
 
@@ -47,6 +48,18 @@ class UnknownOperationResolverTestCase(TestCase):
                 Word("b"),
                 AndOperation(Word("c"), Word("d"))))
         resolver = UnknownOperationResolver(resolve_to=None)
+        self.assertEqual(resolver(tree), expected)
+
+    def test_lucene_resolution_bool(self):
+        tree = parser.parse("a b (+f +g) -(c d) +e")
+        expected = (
+            BoolOperation(
+                Word("a"),
+                Word("b"),
+                Group(BoolOperation(Plus(Word("f")), Plus(Word("g")))),
+                Prohibit(Group(BoolOperation(Word("c"), Word("d")))),
+                Plus(Word('e'))))
+        resolver = UnknownOperationResolver(resolve_to=BoolOperation)
         self.assertEqual(resolver(tree), expected)
 
     def test_lucene_resolution_last_op(self):


### PR DESCRIPTION
The aim is to properly support Lucene search queries with pluses and minuses as described in https://lucidworks.com/post/solr-boolean-operators/