### PR TITLE
feat: boost can be implicit

### DIFF
--- a/luqum/tree.py
+++ b/luqum/tree.py
@@ -371,14 +371,16 @@ class Boost(Item):
 
     def __init__(self, expr, force, **kwargs):
         self.expr = expr
-        self.force = Decimal(force).normalize()
+        self.force = Decimal(force).normalize() if force is not None else 1
+        self.implicit_force = force is None
         super().__init__(**kwargs)
 
     def __repr__(self):
         return "%s(%s, %s)" % (self.__class__.__name__, self.expr.__repr__(), self.force)
 
     def __str__(self, head_tail=False):
-        value = "%s^%s" % (self.expr.__str__(head_tail=True), self.force)
+        force = "" if self.implicit_force else self.force
+        value = "%s^%s" % (self.expr.__str__(head_tail=True), force)
         return self._head_tail(value, head_tail)
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -143,6 +143,17 @@ class TestParser(TestCase):
         self.assertEqual(str(parsed), query)
         self.assertEqual(parsed.unescaped_value, "1000:1000::1/24")
 
+    def test_boost_default_to_one(self):
+        query = "boost^ me^1"
+        parsed = parser.parse(query)
+        tree = UnknownOperation(Boost(Word("boost"), None), Boost(Word("me"), 1))
+        self.assertEqual(parsed, tree)
+        self.assertEqual(parsed.operands[0].force, 1)
+        self.assertEqual(parsed.operands[0].implicit_force, True)
+        self.assertEqual(parsed.operands[1].force, 1)
+        self.assertEqual(parsed.operands[1].implicit_force, False)
+        self.assertEqual(str(parsed), query)
+
     def test_field_with_number(self):
         # non regression for issue #10
         tree = (


### PR DESCRIPTION
as stated in Lucene documentation https://lucene.apache.org/core/2_9_4/queryparsersyntax.html

> By default, the boost factor is 1.

fixes:
- #70