### PR TITLE
Fix precedence for unknown operation and boost

### DIFF
--- a/luqum/parser.py
+++ b/luqum/parser.py
@@ -47,17 +47,17 @@ tokens = (
 
 # precedence rules
 precedence = (
-    ('left', 'OR_OP',),
+    # since IMPLICIT_OP has no lookahead token, everything not defined here has the lowest
+    # precedence (e.g. TERM, PHRASE and REGEX). see https://stackoverflow.com/a/40754838
+    # note that we do not need to include all tokens here, as there is no confusion about
+    # LBRACKET or something; APPROX is also not necessary, as this token can only occur
+    # after a TERM or PHRASE, and there is no confusion about operator precedence
+    ('left', 'IMPLICIT_OP'),
+    ('left', 'OR_OP'),
     ('left', 'AND_OP'),
-    ('nonassoc', 'MINUS',),
-    ('nonassoc', 'PLUS',),
-    ('nonassoc', 'APPROX'),
+    ('nonassoc', 'PLUS', 'MINUS'),
     ('nonassoc', 'BOOST'),
-    ('nonassoc', 'LPAREN', 'RPAREN'),
-    ('nonassoc', 'LBRACKET', 'TO', 'RBRACKET'),
-    ('nonassoc', 'REGEX'),
-    ('nonassoc', 'PHRASE'),
-    ('nonassoc', 'TERM'),
+    ('nonassoc', 'TO'),
 )
 
 # term
@@ -249,7 +249,7 @@ def p_expression_and(p):
 
 
 def p_expression_implicit(p):
-    '''expression : expression expression'''
+    '''expression : expression expression %prec IMPLICIT_OP'''
     p[0] = create_operation(UnknownOperation, p[1], p[2], op_tail="")
     head_tail.binary_operation(p, op_tail="")
 
@@ -312,7 +312,7 @@ def p_proximity(p):
 
 
 def p_boosting(p):
-    '''expression : expression BOOST'''
+    '''unary_expression : unary_expression BOOST'''
     p[0] = Boost(p[1], p[2].value)
     head_tail.post_unary(p)
 

--- a/luqum/parsetab.py
+++ b/luqum/parsetab.py
@@ -6,9 +6,9 @@ _tabversion = '3.10'
 
 _lr_method = 'LALR'
 
-_lr_signature = 'leftOR_OPleftAND_OPnonassocMINUSnonassocPLUSnonassocAPPROXnonassocBOOSTnonassocLPARENRPARENnonassocLBRACKETTORBRACKETnonassocREGEXnonassocPHRASEnonassocTERMAND_OP APPROX BOOST COLUMN LBRACKET LPAREN MINUS NOT OR_OP PHRASE PLUS RBRACKET REGEX RPAREN TERM TOexpression : expression OR_OP expressionexpression : expression AND_OP expressionexpression : expression expressionunary_expression : PLUS unary_expressionunary_expression : MINUS unary_expressionunary_expression : NOT unary_expressionexpression : unary_expressionunary_expression : LPAREN expression RPARENunary_expression : LBRACKET phrase_or_term TO phrase_or_term RBRACKETunary_expression : TERM COLUMN unary_expressionunary_expression : PHRASEunary_expression : PHRASE APPROXexpression : expression BOOSTunary_expression : TERMunary_expression : TERM APPROXunary_expression : REGEXunary_expression : TOphrase_or_term : TERM\n                      | PHRASE'
+_lr_signature = 'leftIMPLICIT_OPleftOR_OPleftAND_OPnonassocPLUSMINUSnonassocBOOSTnonassocTOAND_OP APPROX BOOST COLUMN LBRACKET LPAREN MINUS NOT OR_OP PHRASE PLUS RBRACKET REGEX RPAREN TERM TOexpression : expression OR_OP expressionexpression : expression AND_OP expressionexpression : expression expression %prec IMPLICIT_OPunary_expression : PLUS unary_expressionunary_expression : MINUS unary_expressionunary_expression : NOT unary_expressionexpression : unary_expressionunary_expression : LPAREN expression RPARENunary_expression : LBRACKET phrase_or_term TO phrase_or_term RBRACKETunary_expression : TERM COLUMN unary_expressionunary_expression : PHRASEunary_expression : PHRASE APPROXunary_expression : unary_expression BOOSTunary_expression : TERMunary_expression : TERM APPROXunary_expression : REGEXunary_expression : TOphrase_or_term : TERM\n                      | PHRASE'
     
-_lr_action_items = {'PLUS':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[3,3,-7,3,3,3,3,-17,-14,-11,-16,3,3,3,-13,-4,-5,-6,3,3,-15,-12,3,3,-8,-10,-9,]),'MINUS':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[4,4,-7,4,4,4,4,-17,-14,-11,-16,4,4,4,-13,-4,-5,-6,4,4,-15,-12,4,4,-8,-10,-9,]),'NOT':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[5,5,-7,5,5,5,5,-17,-14,-11,-16,5,5,5,-13,-4,-5,-6,5,5,-15,-12,-1,-2,-8,-10,-9,]),'LPAREN':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[6,6,-7,6,6,6,6,-17,-14,-11,-16,6,6,6,-13,-4,-5,-6,6,6,-15,-12,6,6,-8,-10,-9,]),'LBRACKET':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[7,7,-7,7,7,7,7,-17,-14,-11,-16,7,7,7,-13,-4,-5,-6,7,7,-15,-12,7,7,-8,-10,-9,]),'TERM':([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,29,30,32,],[9,9,-7,9,9,9,9,21,-17,-14,-11,-16,9,9,9,-13,-4,-5,-6,9,9,-15,-12,9,9,-8,21,-10,-9,]),'PHRASE':([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,29,30,32,],[10,10,-7,10,10,10,10,22,-17,-14,-11,-16,10,10,10,-13,-4,-5,-6,10,10,-15,-12,10,10,-8,22,-10,-9,]),'REGEX':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[11,11,-7,11,11,11,11,-17,-14,-11,-16,11,11,11,-13,-4,-5,-6,11,11,-15,-12,11,11,-8,-10,-9,]),'TO':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,30,32,],[8,8,-7,8,8,8,8,-17,-14,-11,-16,8,8,8,-13,-4,-5,-6,8,29,-18,-19,8,-15,-12,8,8,-8,-10,-9,]),'$end':([1,2,8,9,10,11,12,15,16,17,18,24,25,26,27,28,30,32,],[0,-7,-17,-14,-11,-16,-3,-13,-4,-5,-6,-15,-12,-1,-2,-8,-10,-9,]),'OR_OP':([1,2,8,9,10,11,12,15,16,17,18,19,24,25,26,27,28,30,32,],[13,-7,-17,-14,-11,-16,13,-13,-4,-5,-6,13,-15,-12,-1,-2,-8,-10,-9,]),'AND_OP':([1,2,8,9,10,11,12,15,16,17,18,19,24,25,26,27,28,30,32,],[14,-7,-17,-14,-11,-16,14,-13,-4,-5,-6,14,-15,-12,14,-2,-8,-10,-9,]),'BOOST':([1,2,8,9,10,11,12,15,16,17,18,19,24,25,26,27,28,30,32,],[15,-7,-17,-14,-11,-16,15,-13,-4,-5,-6,15,-15,-12,15,15,-8,-10,-9,]),'RPAREN':([2,8,9,10,11,12,15,16,17,18,19,24,25,26,27,28,30,32,],[-7,-17,-14,-11,-16,-3,-13,-4,-5,-6,28,-15,-12,-1,-2,-8,-10,-9,]),'COLUMN':([9,],[23,]),'APPROX':([9,10,],[24,25,]),'RBRACKET':([21,22,31,],[-18,-19,32,]),}
+_lr_action_items = {'PLUS':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[3,3,-7,3,3,3,3,-17,-14,-11,-16,3,3,3,-13,-4,-5,-6,3,3,-15,-12,3,3,-8,-10,-9,]),'MINUS':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[4,4,-7,4,4,4,4,-17,-14,-11,-16,4,4,4,-13,-4,-5,-6,4,4,-15,-12,4,4,-8,-10,-9,]),'NOT':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[5,5,-7,5,5,5,5,-17,-14,-11,-16,-3,5,5,-13,-4,-5,-6,5,5,-15,-12,-1,-2,-8,-10,-9,]),'LPAREN':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[6,6,-7,6,6,6,6,-17,-14,-11,-16,-3,6,6,-13,-4,-5,-6,6,6,-15,-12,-1,-2,-8,-10,-9,]),'LBRACKET':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[7,7,-7,7,7,7,7,-17,-14,-11,-16,-3,7,7,-13,-4,-5,-6,7,7,-15,-12,-1,-2,-8,-10,-9,]),'TERM':([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,29,30,32,],[9,9,-7,9,9,9,9,21,-17,-14,-11,-16,-3,9,9,-13,-4,-5,-6,9,9,-15,-12,-1,-2,-8,21,-10,-9,]),'PHRASE':([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,29,30,32,],[10,10,-7,10,10,10,10,22,-17,-14,-11,-16,-3,10,10,-13,-4,-5,-6,10,10,-15,-12,-1,-2,-8,22,-10,-9,]),'REGEX':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,23,24,25,26,27,28,30,32,],[11,11,-7,11,11,11,11,-17,-14,-11,-16,-3,11,11,-13,-4,-5,-6,11,11,-15,-12,-1,-2,-8,-10,-9,]),'TO':([0,1,2,3,4,5,6,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,30,32,],[8,8,-7,8,8,8,8,-17,-14,-11,-16,8,8,8,-13,-4,-5,-6,8,29,-18,-19,8,-15,-12,8,8,-8,-10,-9,]),'$end':([1,2,8,9,10,11,12,15,16,17,18,24,25,26,27,28,30,32,],[0,-7,-17,-14,-11,-16,-3,-13,-4,-5,-6,-15,-12,-1,-2,-8,-10,-9,]),'OR_OP':([1,2,8,9,10,11,12,15,16,17,18,19,24,25,26,27,28,30,32,],[13,-7,-17,-14,-11,-16,13,-13,-4,-5,-6,13,-15,-12,-1,-2,-8,-10,-9,]),'AND_OP':([1,2,8,9,10,11,12,15,16,17,18,19,24,25,26,27,28,30,32,],[14,-7,-17,-14,-11,-16,14,-13,-4,-5,-6,14,-15,-12,14,-2,-8,-10,-9,]),'RPAREN':([2,8,9,10,11,12,15,16,17,18,19,24,25,26,27,28,30,32,],[-7,-17,-14,-11,-16,-3,-13,-4,-5,-6,28,-15,-12,-1,-2,-8,-10,-9,]),'BOOST':([2,8,9,10,11,15,16,17,18,24,25,28,30,32,],[15,-17,-14,-11,-16,-13,15,15,15,-15,-12,-8,15,-9,]),'COLUMN':([9,],[23,]),'APPROX':([9,10,],[24,25,]),'RBRACKET':([21,22,31,],[-18,-19,32,]),}
 
 _lr_action = {}
 for _k, _v in _lr_action_items.items():
@@ -27,23 +27,23 @@ for _k, _v in _lr_goto_items.items():
 del _lr_goto_items
 _lr_productions = [
   ("S' -> expression","S'",1,None,None,None),
-  ('expression -> expression OR_OP expression','expression',3,'p_expression_or','parser.py',191),
-  ('expression -> expression AND_OP expression','expression',3,'p_expression_and','parser.py',196),
-  ('expression -> expression expression','expression',2,'p_expression_implicit','parser.py',201),
-  ('unary_expression -> PLUS unary_expression','unary_expression',2,'p_expression_plus','parser.py',206),
-  ('unary_expression -> MINUS unary_expression','unary_expression',2,'p_expression_minus','parser.py',211),
-  ('unary_expression -> NOT unary_expression','unary_expression',2,'p_expression_not','parser.py',216),
-  ('expression -> unary_expression','expression',1,'p_expression_unary','parser.py',221),
-  ('unary_expression -> LPAREN expression RPAREN','unary_expression',3,'p_grouping','parser.py',226),
-  ('unary_expression -> LBRACKET phrase_or_term TO phrase_or_term RBRACKET','unary_expression',5,'p_range','parser.py',231),
-  ('unary_expression -> TERM COLUMN unary_expression','unary_expression',3,'p_field_search','parser.py',238),
-  ('unary_expression -> PHRASE','unary_expression',1,'p_quoting','parser.py',246),
-  ('unary_expression -> PHRASE APPROX','unary_expression',2,'p_proximity','parser.py',251),
-  ('expression -> expression BOOST','expression',2,'p_boosting','parser.py',256),
-  ('unary_expression -> TERM','unary_expression',1,'p_terms','parser.py',261),
-  ('unary_expression -> TERM APPROX','unary_expression',2,'p_fuzzy','parser.py',266),
-  ('unary_expression -> REGEX','unary_expression',1,'p_regex','parser.py',270),
-  ('unary_expression -> TO','unary_expression',1,'p_to_as_term','parser.py',275),
-  ('phrase_or_term -> TERM','phrase_or_term',1,'p_phrase_or_term','parser.py',280),
-  ('phrase_or_term -> PHRASE','phrase_or_term',1,'p_phrase_or_term','parser.py',281),
+  ('expression -> expression OR_OP expression','expression',3,'p_expression_or','parser.py',240),
+  ('expression -> expression AND_OP expression','expression',3,'p_expression_and','parser.py',246),
+  ('expression -> expression expression','expression',2,'p_expression_implicit','parser.py',252),
+  ('unary_expression -> PLUS unary_expression','unary_expression',2,'p_expression_plus','parser.py',258),
+  ('unary_expression -> MINUS unary_expression','unary_expression',2,'p_expression_minus','parser.py',264),
+  ('unary_expression -> NOT unary_expression','unary_expression',2,'p_expression_not','parser.py',270),
+  ('expression -> unary_expression','expression',1,'p_expression_unary','parser.py',276),
+  ('unary_expression -> LPAREN expression RPAREN','unary_expression',3,'p_grouping','parser.py',281),
+  ('unary_expression -> LBRACKET phrase_or_term TO phrase_or_term RBRACKET','unary_expression',5,'p_range','parser.py',287),
+  ('unary_expression -> TERM COLUMN unary_expression','unary_expression',3,'p_field_search','parser.py',295),
+  ('unary_expression -> PHRASE','unary_expression',1,'p_quoting','parser.py',304),
+  ('unary_expression -> PHRASE APPROX','unary_expression',2,'p_proximity','parser.py',309),
+  ('unary_expression -> unary_expression BOOST','unary_expression',2,'p_boosting','parser.py',315),
+  ('unary_expression -> TERM','unary_expression',1,'p_terms','parser.py',321),
+  ('unary_expression -> TERM APPROX','unary_expression',2,'p_fuzzy','parser.py',326),
+  ('unary_expression -> REGEX','unary_expression',1,'p_regex','parser.py',332),
+  ('unary_expression -> TO','unary_expression',1,'p_to_as_term','parser.py',338),
+  ('phrase_or_term -> TERM','phrase_or_term',1,'p_phrase_or_term','parser.py',344),
+  ('phrase_or_term -> PHRASE','phrase_or_term',1,'p_phrase_or_term','parser.py',345),
 ]


### PR DESCRIPTION
The precedence for the unknown (implied) operation is always lower than for AND and OR operations, as evidenced by how the current Apache Lucene library handles this. A simple `TreeVisitor` on a `PrecedenceQueryParser` shows the following:

```
Default operator: OR
Entered query:    1 2 AND 3 4
Parsed query:     1 (+2 +3) 4
--------
BooleanQuery(MUST): 1 (+2 +3) 4
  BooleanQuery(SHOULD): 1 (+2 +3) 4
    TermQuery: 4
    TermQuery: 1
    BooleanQuery(MUST): +2 +3
      TermQuery: 2
      TermQuery: 3

Default operator: OR
Entered query:    1 2 OR 3 4
Parsed query:     1 (2 3) 4
--------
BooleanQuery(MUST): 1 (2 3) 4
  BooleanQuery(SHOULD): 1 (2 3) 4
    TermQuery: 4
    TermQuery: 1
    BooleanQuery(MUST): 2 3
      BooleanQuery(SHOULD): 2 3
        TermQuery: 3
        TermQuery: 2

Default operator: OR
Entered query:    1 2 OR 3 4 AND 5 OR 6 7 8
Parsed query:     1 (2 3) ((+4 +5) 6) 7 8
--------
BooleanQuery(MUST): 1 (2 3) ((+4 +5) 6) 7 8
  BooleanQuery(SHOULD): 1 (2 3) ((+4 +5) 6) 7 8
    TermQuery: 8
    TermQuery: 1
    TermQuery: 7
    BooleanQuery(MUST): 2 3
      BooleanQuery(SHOULD): 2 3
        TermQuery: 3
        TermQuery: 2
    BooleanQuery(MUST): (+4 +5) 6
      BooleanQuery(SHOULD): (+4 +5) 6
        TermQuery: 6
        BooleanQuery(MUST): +4 +5
          TermQuery: 4
          TermQuery: 5
```
The results are similar when the default operator is changed to AND.

This commit adds a fictitious token for the invisible implied operation, giving it the lowest precedence. This should ensure that `a b AND c d` correctly translates to `a (b AND c) d`, contrasting the current `(a (b AND (c d))`.

To make this work, the list of precedence items had to shrink quite a bit, as there were several tokens in there that do not require disambiguation, and did cause issues with the fact that there's no lookahead token for the implied operation.

In the cleanup of this list, we also noticed that precedence of the boost operator was configured incorrectly, so that was fixed as well. This ensures that +2^1 becomes +(2^1).