### PR TITLE
fix: allowed Range as expr in SearchField

### DIFF
--- a/luqum/check.py
+++ b/luqum/check.py
@@ -44,7 +44,7 @@ class LuceneCheck:
     SIMPLE_EXPR_FIELDS = (
         tree.Boost, tree.Proximity, tree.Fuzzy, tree.Word, tree.Phrase)
 
-    FIELD_EXPR_FIELDS = tuple(list(SIMPLE_EXPR_FIELDS) + [tree.FieldGroup])
+    FIELD_EXPR_FIELDS = tuple(list(SIMPLE_EXPR_FIELDS) + [tree.FieldGroup, tree.Range])
 
     def __init__(self, zeal=0):
         self.zeal = zeal

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -135,6 +135,12 @@ class TestCheck(TestCase):
         self.assertIn("Unknown item type", check.errors(query)[0])
         self.assertIn("Unknown item type", check.errors(query)[1])
 
+    def test_search_field_range(self):
+        check = LuceneCheck()
+        query = SearchField("foo", Range("1", "10"))
+        self.assertTrue(check(query))
+        self.assertEqual(check.errors(query), [])
+
 
 class CheckVisitorTestCase(TestCase):
 


### PR DESCRIPTION
-  Added tree.Range to FIELD_EXPR_FIELDS in LuceneCheck
- Added test_range to test_check.py
fixes: #92