### PR TITLE
recognize E_NESTED override

### DIFF
--- a/luqum/elasticsearch/tree.py
+++ b/luqum/elasticsearch/tree.py
@@ -435,7 +435,7 @@ class ElasticSearchItemFactory:
                 *args,
                 **kwargs
             )
-        elif cls is ENested:
+        elif issubclass(cls, ENested):
             return cls(
                 nested_fields=self._nested_fields,
                 *args,


### PR DESCRIPTION
https://github.com/jurismarches/luqum/issues/102

Seems this should be `issubclass` to respect `E_NESTED` override.